### PR TITLE
feat: ページ遷移時にスクロール位置をトップに戻すスクリプトを追加し、Firebase設定の検証を実装

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -126,6 +126,14 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
     
     <ViewTransitions />
 
+    <!-- ページ遷移時にスクロール位置をトップに戻すスクリプト -->
+    <script>
+      document.addEventListener('astro:page-load', () => {
+        // ページ遷移完了後にスクロールを上に戻す
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+    </script>
+
     <!-- スタイルは src/styles/main.scss に集約 -->
   </head>
   <body class="flex flex-col min-h-screen bg-slate-900">

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -14,9 +14,25 @@ const firebaseConfig = {
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
-// Firebaseアプリを初期化（既に初期化されていれば既存のものを利用）
-const app = getApps().length > 0 ? getApp() : initializeApp(firebaseConfig);
+// Firebase設定の検証
+const hasValidConfig = Object.values(firebaseConfig).every(value => value && value !== 'undefined');
 
-// Firestoreのインスタンスを取得
-export const db = getFirestore(app);
-export const auth = getAuth(app);
+let app: any = null;
+let db: any = null;
+let auth: any = null;
+
+// 有効な設定がある場合のみFirebaseを初期化
+if (hasValidConfig) {
+  try {
+    // Firebaseアプリを初期化（既に初期化されていれば既存のものを利用）
+    app = getApps().length > 0 ? getApp() : initializeApp(firebaseConfig);
+    
+    // Firestoreのインスタンスを取得
+    db = getFirestore(app);
+    auth = getAuth(app);
+  } catch (error) {
+    console.warn('Firebase initialization failed:', error);
+  }
+}
+
+export { db, auth };

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -939,13 +939,15 @@ h6,
       }
       
       /* タイトルの行数制限 - 確実に表示 */
-      display: -webkit-box !important;
-      -webkit-box-orient: vertical !important;
-      overflow: hidden !important;
-      word-break: break-word !important;
-      
-      /* スマホでは2行表示を確保 */
-      -webkit-line-clamp: 2 !important;
+      & {
+        display: -webkit-box !important;
+        -webkit-box-orient: vertical !important;
+        overflow: hidden !important;
+        word-break: break-word !important;
+        
+        /* スマホでは2行表示を確保 */
+        -webkit-line-clamp: 2 !important;
+      }
       
       @media (max-width: 640px) {
         -webkit-line-clamp: 2 !important; /* スマホでも2行確保 */


### PR DESCRIPTION
- ページ遷移完了後にスクロールを上に戻すスクリプトを追加
- Firebaseの初期化時に設定の検証を行い、エラーハンドリングを追加
- スタイルシートのコードを整理し、可読性を向上