### PR TITLE
feat: ドメインを新しいURLに変更し、サイトマップのURLを更新

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import vercel from "@astrojs/vercel"; // vercelをインポート
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
-  site: "https://my-tech-blog.vercel.app", // 本番ドメイン
+  site: "https://monologger.dev", // 新しいドメインに変更
   output: "server", // outputは"server"のまま
   adapter: vercel(), // adapterをvercel()に変更
   integrations: [tailwind(), sitemap(), react()],

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,7 @@
 User-agent: *
 Allow: /
 
-# Sitemap
-Sitemap: https://my-tech-blog.vercel.app/sitemap-index.xml
+Sitemap: https://monologger.dev/sitemap-index.xml
 
 # Block access to admin or private areas (if any in the future)
 Disallow: /admin/


### PR DESCRIPTION
- 本番ドメインを「https://monologger.dev」に変更
- robots.txt内のサイトマップURLを新しいドメインに合わせて更新