### PR TITLE
feat: 動的サイトマップとカノニカルURLの改善

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,6 +15,8 @@ export interface Props {
   modifiedTime?: string;
   articleType?: string;
   noIndex?: boolean;
+  // 任意でページ側からカノニカルURLを上書き可能にする
+  canonicalUrl?: string;
 }
 
 const {
@@ -27,6 +29,7 @@ const {
   modifiedTime,
   articleType = "website",
   noIndex = false,
+  canonicalUrl: canonicalUrlOverride,
 } = Astro.props;
 
 const siteTitle = "Monologger";
@@ -34,8 +37,19 @@ const title = pageTitle ? `${pageTitle} | ${siteTitle}` : siteTitle;
 const ogpImageUrl =
   ogImageUrl || new URL("default-og-image.svg", Astro.site).href;
 
-// カノニカルURLの生成
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
+// カノニカルURLの生成（末尾スラッシュを統一し、ページネーション(page)のみ反映）
+function buildDefaultCanonicalUrl() {
+  const rawPath = Astro.url.pathname || "/";
+  const normalizedPath = rawPath.endsWith("/") ? rawPath : `${rawPath}/`;
+  const url = new URL(normalizedPath, Astro.site);
+  const pageParam = Astro.url.searchParams.get("page");
+  if (pageParam && pageParam !== "1") {
+    url.searchParams.set("page", pageParam);
+  }
+  return url.href;
+}
+
+const canonicalUrl = canonicalUrlOverride || buildDefaultCanonicalUrl();
 ---
 
 <!doctype html>
@@ -102,30 +116,26 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
     <link rel="prefetch" href="/search" />
     
     <!-- Structured Data - Website Schema -->
-    <script type="application/ld+json">
-      {
-        JSON.stringify({
-          "@context": "https://schema.org",
-          "@type": "WebSite",
-          "name": siteTitle,
-          "url": Astro.site,
-          "description": pageDescription,
-          "publisher": {
-            "@type": "Organization",
-            "name": siteTitle,
-            "logo": {
-              "@type": "ImageObject",
-              "url": new URL("/logo.svg", Astro.site).href
-            }
-          },
-          "potentialAction": {
-            "@type": "SearchAction",
-            "target": new URL("/search?q={search_term_string}", Astro.site).href,
-            "query-input": "required name=search_term_string"
-          }
-        })
+    <script type="application/ld+json" is:inline>{JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": siteTitle,
+      "url": Astro.site,
+      "description": pageDescription,
+      "publisher": {
+        "@type": "Organization",
+        "name": siteTitle,
+        "logo": {
+          "@type": "ImageObject",
+          "url": new URL("/logo.svg", Astro.site).href
+        }
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": new URL("/search?q={search_term_string}", Astro.site).href,
+        "query-input": "required name=search_term_string"
       }
-    </script>
+    })}</script>
 
     <!-- Web Vitals (console only) -->
     <script>

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -81,9 +81,7 @@ const breadcrumbItems = [
     />
     
     <!-- Article Specific Structured Data -->
-    <script type="application/ld+json">
-      {
-        JSON.stringify({
+    <script type="application/ld+json" is:inline>{JSON.stringify({
           "@context": "https://schema.org",
           "@type": "BlogPosting",
           "headline": post.title,
@@ -116,14 +114,10 @@ const breadcrumbItems = [
             "@type": "ReadAction",
             "target": [Astro.url.href]
           }
-        })
-      }
-    </script>
+    })}</script>
 
     <!-- Breadcrumb Structured Data -->
-    <script type="application/ld+json">
-      {
-        JSON.stringify({
+    <script type="application/ld+json" is:inline>{JSON.stringify({
           "@context": "https://schema.org",
           "@type": "BreadcrumbList",
           "itemListElement": [
@@ -152,9 +146,7 @@ const breadcrumbItems = [
               "item": Astro.url.href
             }
           ].filter(Boolean)
-        })
-      }
-    </script>
+    })}</script>
   </Fragment>
   
   <main class="min-h-screen bg-slate-900">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -77,12 +77,27 @@ const breadcrumbItems = [
 if (categoryParam && categoryParam !== "all") {
   breadcrumbItems.push({ name: categoryParam, href: undefined });
 }
+
+// 正規URL（カノニカル）を計算
+const canonicalUrlForList = (() => {
+  if (categoryParam && categoryParam !== 'all') {
+    const p = `/category/${encodeURIComponent(categoryParam)}/`;
+    const url = new URL(p, Astro.site);
+    const pageParamLocal = Astro.url.searchParams.get('page');
+    if (pageParamLocal && pageParamLocal !== '1') url.searchParams.set('page', pageParamLocal);
+    return url.href;
+  }
+  const url = new URL('/blog/', Astro.site);
+  if (currentPage > 1) url.searchParams.set('page', String(currentPage));
+  return url.href;
+})();
 ---
 
 <BaseLayout 
   pageTitle={pageTitle}
   pageDescription="Monologgerのブログ記事一覧です。ITに触れて気づいたことや、試してよかったツールのメモが並びます。"
   keywords="ブログ, 記事一覧, テクノロジー, ガジェット, 開発, プログラミング, コーディング, AI, 備忘録, 気づき"
+  canonicalUrl={canonicalUrlForList}
 >
   <div class="min-h-screen bg-slate-900 text-white">
     <!-- ヒーローセクション -->

--- a/src/pages/category/[categoryName].astro
+++ b/src/pages/category/[categoryName].astro
@@ -47,9 +47,7 @@ const breadcrumbItems = [
   pageDescription={pageDescription}
   keywords={keywords}
 >
-  <script slot="head" type="application/ld+json">
-    {
-      JSON.stringify({
+  <script slot="head" type="application/ld+json" is:inline>{JSON.stringify({
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": pageTitle,
@@ -71,8 +69,7 @@ const breadcrumbItems = [
             }
           }))
         }
-      })
-    }
+      })}
   </script>
   
   <main class="min-h-screen bg-slate-900">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -62,12 +62,20 @@ const categoryChips: string[] = Array.from(
     )
   )
 ).slice(0, 6);
+
+// カノニカルURL（ホーム）
+const canonicalHome = (() => {
+  const url = new URL('/', Astro.site);
+  if (currentPage > 1) url.searchParams.set('page', String(currentPage));
+  return url.href;
+})();
 ---
 
 <BaseLayout
   pageTitle="気づきメモ - 最新の記事"
   pageDescription="ITに触れて生まれた日々の気づきや備忘録をゆるくまとめています。ガジェットや開発の小ネタ、作業をラクにするヒントなど。"
   keywords="テクノロジー, ガジェット, 開発, プログラミング, コーディング, AI, Web開発, JavaScript, React, Astro, 備忘録, 気づき"
+  canonicalUrl={canonicalHome}
 >
   <Fragment slot="head">
     {
@@ -81,9 +89,7 @@ const categoryChips: string[] = Array.from(
     }
   </Fragment>
   <!-- ホームページ用の構造化データ -->
-  <script slot="head" type="application/ld+json">
-    {
-      JSON.stringify({
+  <script slot="head" type="application/ld+json" is:inline>{JSON.stringify({
         "@context": "https://schema.org",
         "@type": "Blog",
         "name": "Monologger",
@@ -118,8 +124,7 @@ const categoryChips: string[] = Array.from(
           },
           "image": post.eyecatch?.url || new URL("/placeholder.svg", Astro.site).href
         }))
-      })
-    }
+      })}
   </script>
   <main class="min-h-screen bg-slate-900">
     <!-- First View (FB) -->


### PR DESCRIPTION
- microCMSから動的に記事とカテゴリを取得し、サイトマップに追加
- 各ページでカノニカルURLを生成するロジックを追加し、SEO対策を強化
- 構造化データのスクリプトをインライン化し、パフォーマンスを向上
- ホームページ、ブログ一覧、カテゴリページにカノニカルURLを適用